### PR TITLE
Nacos: configure multiple apps on same pod

### DIFF
--- a/proxyd/cmd/proxyd/main.go
+++ b/proxyd/cmd/proxyd/main.go
@@ -25,10 +25,6 @@ var (
 	GitDate    = ""
 )
 
-const (
-	nacosExternalListenAddr = "NACOS_EXTERNAL_LISTEN_ADDR"
-)
-
 func main() {
 	// Set up logger with a default INFO level in case we fail to parse flags.
 	// Otherwise the final critical log won't show what the parsing error was.
@@ -73,9 +69,10 @@ func main() {
 	}
 
 	// Register after start.
-	externalListenAddr := config.Nacos.ExternalListenAddr
-	if os.Getenv(nacosExternalListenAddr) != "" {
-		externalListenAddr = os.Getenv(nacosExternalListenAddr)
+	externalIP := config.Nacos.ExternalIP
+	podIpEnv := "MY_POD_IP"
+	if os.Getenv(podIpEnv) != "" {
+		externalIP = os.Getenv(podIpEnv)
 	}
 
 	// Register after start.
@@ -84,7 +81,8 @@ func main() {
 			config.Nacos.URLs,
 			config.Nacos.NamespaceId,
 			config.Nacos.ApplicationName,
-			externalListenAddr,
+			externalIP,
+			config.Nacos.ExternalPorts,
 		)
 	}
 

--- a/proxyd/cmd/proxyd/main.go
+++ b/proxyd/cmd/proxyd/main.go
@@ -73,14 +73,13 @@ func main() {
 	}
 
 	// Register after start.
-	externalIP := config.Nacos.ExternalIP
-	if os.Getenv(podIpEnv) != "" {
-		externalIP = os.Getenv(podIpEnv)
-		log.Warn("External IP replaced by env `MY_POD_IP`", "ExternalIP", externalIP)
-	}
-
-	// Register after start.
 	if len(config.Nacos.URLs) > 0 {
+		externalIP := config.Nacos.ExternalIP
+		if os.Getenv(podIpEnv) != "" {
+			externalIP = os.Getenv(podIpEnv)
+			log.Warn("External IP replaced by env `MY_POD_IP`", "ExternalIP", externalIP)
+		}
+
 		proxyd.StartNacosClient(
 			config.Nacos.URLs,
 			config.Nacos.NamespaceId,

--- a/proxyd/cmd/proxyd/main.go
+++ b/proxyd/cmd/proxyd/main.go
@@ -25,6 +25,10 @@ var (
 	GitDate    = ""
 )
 
+const (
+	podIpEnv = "MY_POD_IP"
+)
+
 func main() {
 	// Set up logger with a default INFO level in case we fail to parse flags.
 	// Otherwise the final critical log won't show what the parsing error was.
@@ -70,9 +74,9 @@ func main() {
 
 	// Register after start.
 	externalIP := config.Nacos.ExternalIP
-	podIpEnv := "MY_POD_IP"
 	if os.Getenv(podIpEnv) != "" {
 		externalIP = os.Getenv(podIpEnv)
+		log.Warn("External IP replaced by env `MY_POD_IP`", "ExternalIP", externalIP)
 	}
 
 	// Register after start.

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -60,10 +60,11 @@ type RateLimitConfig struct {
 }
 
 type NacosConfig struct {
-	URLs               string `toml:"urls"`
-	NamespaceId        string `toml:"namespace_id"`
-	ApplicationName    string `toml:"application_name"`
-	ExternalListenAddr string `toml:"external_listen_addr"`
+	URLs            string `toml:"urls"`
+	NamespaceId     string `toml:"namespace_id"`
+	ApplicationName string `toml:"application_name"`
+	ExternalIP      string `toml:"external_ip"`
+	ExternalPorts   string `toml:"external_ports"`
 }
 
 type RateLimitMethodOverride struct {

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/ledgerwatch/log/v3 v3.9.0
 	github.com/nacos-group/nacos-sdk-go v1.1.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
@@ -55,7 +54,6 @@ require (
 	github.com/getsentry/sentry-go v0.25.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -69,8 +67,6 @@ require (
 	github.com/klauspost/compress v1.17.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect

--- a/proxyd/go.sum
+++ b/proxyd/go.sum
@@ -94,8 +94,6 @@ github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F4
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-redsync/redsync/v4 v4.10.0 h1:hTeAak4C73mNBQSTq6KCKDFaiIlfC+z5yTTl8fCJuBs=
 github.com/go-redsync/redsync/v4 v4.10.0/go.mod h1:ZfayzutkgeBmEmBlUR3j+rF6kN44UUGtEdfzhBFZTPc=
-github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
-github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -166,13 +164,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/ledgerwatch/log/v3 v3.9.0 h1:iDwrXe0PVwBC68Dd94YSsHbMgQ3ufsgjzXtFNFVZFRk=
-github.com/ledgerwatch/log/v3 v3.9.0/go.mod h1:EiAY6upmI/6LkNhOVxb4eVsmsP11HZCnZ3PlJMjYiqE=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -319,10 +310,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=

--- a/proxyd/nacos.go
+++ b/proxyd/nacos.go
@@ -49,11 +49,26 @@ func StartNacosClient(urls string, namespace string, name string, externalAddr s
 
 	appNames := strings.Split(name, ",")
 	addrs := strings.Split(externalAddr, ",")
+
+	if len(appNames) != len(addrs) {
+		panic(fmt.Sprintf("Nacos: number of app names not equal to number of external addresses."))
+	}
+
+	firstIP := ""
 	for i := 0; i < len(addrs); i++ {
 		ip, port, err := ResolveIPAndPort(addrs[i])
 		if err != nil {
 			log.Error(fmt.Sprintf("failed to resolve %s error: %s", externalAddr, err.Error()))
 			return
+		}
+
+		// Verify same IP address is used for multiple ports.
+		if firstIP == "" {
+			firstIP = ip
+		} else {
+			if firstIP != ip {
+				panic(fmt.Sprintf("This should not happen. firstIP: %s, ip: %s", firstIP, ip))
+			}
 		}
 
 		// Register on each ip,port instance.

--- a/proxyd/nacos.go
+++ b/proxyd/nacos.go
@@ -21,13 +21,11 @@ const (
 )
 
 // StartNacosClient start nacos client and register rest service in nacos
+//
+// Each param except `namespace` are comma-separated strings unless there is only 1.
+// Eg. urls = "online-nacosapi.okg.com:80"
+// Eg. urls = "online-nacosapi.okg.com:80,test.okg.com:123"
 func StartNacosClient(urls string, namespace string, name string, externalAddr string) {
-	ip, port, err := ResolveIPAndPort(externalAddr)
-	if err != nil {
-		log.Error(fmt.Sprintf("failed to resolve %s error: %s", externalAddr, err.Error()))
-		return
-	}
-
 	serverConfigs, err := getServerConfigs(urls)
 	if err != nil {
 		log.Error(fmt.Sprintf("failed to resolve nacos server url %s: %s", urls, err.Error()))
@@ -39,7 +37,7 @@ func StartNacosClient(urls string, namespace string, name string, externalAddr s
 			TimeoutMs:           defaultTimeoutMs,
 			ListenInterval:      defaultListenInterval,
 			NotLoadCacheAtStart: true,
-			NamespaceId:         namespace,
+			NamespaceId:         namespace, // same namespace is shared for all server configs
 			LogDir:              "/dev/null",
 			LogLevel:            "error",
 		},
@@ -49,28 +47,41 @@ func StartNacosClient(urls string, namespace string, name string, externalAddr s
 		return
 	}
 
-	_, err = client.RegisterInstance(vo.RegisterInstanceParam{
-		Ip:          ip,
-		Port:        port,
-		ServiceName: name,
-		Weight:      defaultWeight,
-		ClusterName: "DEFAULT",
-		Enable:      true,
-		Healthy:     true,
-		Ephemeral:   true,
-		Metadata: map[string]string{
-			"preserved.register.source": "GO",
-			"app_registry_tag":          strconv.FormatInt(time.Now().Unix(), 10),
-		},
-	})
-	if err != nil {
-		log.Error(fmt.Sprintf("failed to register instance in nacos server. error: %s", err.Error()))
-		return
+	appNames := strings.Split(name, ",")
+	addrs := strings.Split(externalAddr, ",")
+	for i := 0; i < len(addrs); i++ {
+		ip, port, err := ResolveIPAndPort(addrs[i])
+		if err != nil {
+			log.Error(fmt.Sprintf("failed to resolve %s error: %s", externalAddr, err.Error()))
+			return
+		}
+
+		// Register on each ip,port instance.
+		_, err = client.RegisterInstance(vo.RegisterInstanceParam{
+			Ip:          ip,
+			Port:        port,
+			ServiceName: appNames[i],
+			Weight:      defaultWeight,
+			ClusterName: "DEFAULT",
+			Enable:      true,
+			Healthy:     true,
+			Ephemeral:   true,
+			Metadata: map[string]string{
+				"preserved.register.source": "GO",
+				"app_registry_tag":          strconv.FormatInt(time.Now().Unix(), 10),
+			},
+		})
+		if err != nil {
+			log.Error(fmt.Sprintf("failed to register instance in nacos server. error: %s", err.Error()))
+			return
+		}
 	}
+
 	log.Info("register application instance in nacos successfully")
 }
 
 // ResolveIPAndPort resolve ip and port from addr
+// If 127.0.0.1, the same default port will be used.
 func ResolveIPAndPort(addr string) (string, uint64, error) {
 	laddr := strings.Split(addr, ":")
 	ip := laddr[0]

--- a/proxyd/nacos_test.go
+++ b/proxyd/nacos_test.go
@@ -37,16 +37,25 @@ func TestManyResolveIPAndPort(t *testing.T) {
 		expectedPorts []uint64
 	}{
 		{
+			// Single declaration should not fail.
+			"127.0.0.1:7001",
+			[]string{GetLocalIP()},
+			[]uint64{defaultPort},
+		},
+		{
+			// Defaults to local IP.
 			"127.0.0.1:7001,127.0.0.1:7002",
 			[]string{GetLocalIP(), GetLocalIP()},
 			[]uint64{defaultPort, defaultPort},
 		},
+		// {
+		// 	// This should panic on start (to warn about misconfiguration)
+		// 	"127.0.0.3:7001,127.0.0.2:7002",
+		// 	[]string{},
+		// 	[]uint64{7001},
+		// },
 		{
-			"127.0.0.3:7001,127.0.0.2:7002",
-			[]string{"127.0.0.3", "127.0.0.2"},
-			[]uint64{7001, 7002},
-		},
-		{
+			// Same IPs, different ports.
 			"127.0.0.2:7001,127.0.0.2:7002",
 			[]string{"127.0.0.2", "127.0.0.2"},
 			[]uint64{7001, 7002},

--- a/proxyd/nacos_test.go
+++ b/proxyd/nacos_test.go
@@ -1,0 +1,71 @@
+package proxyd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nacos-group/nacos-sdk-go/common/constant"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerConfigsFromUrls(t *testing.T) {
+	urls := "online-nacosapi.okg.com:80,online-nacosapi2.okg.com:123"
+	configs, err := getServerConfigs(urls)
+
+	assert.Nil(t, err)
+	assert.Equal(t, configs, []constant.ServerConfig{
+		{
+			Scheme:      "",
+			ContextPath: "",
+			IpAddr:      "online-nacosapi.okg.com",
+			Port:        80,
+		},
+		{
+			Scheme:      "",
+			ContextPath: "",
+			IpAddr:      "online-nacosapi2.okg.com",
+			Port:        123,
+		},
+	})
+}
+
+func TestManyResolveIPAndPort(t *testing.T) {
+	testcases := []struct {
+		input         string
+		expectedIps   []string
+		expectedPorts []uint64
+	}{
+		{
+			"127.0.0.1:7001,127.0.0.1:7002",
+			[]string{GetLocalIP(), GetLocalIP()},
+			[]uint64{defaultPort, defaultPort},
+		},
+		{
+			"127.0.0.3:7001,127.0.0.2:7002",
+			[]string{"127.0.0.3", "127.0.0.2"},
+			[]uint64{7001, 7002},
+		},
+	}
+
+	for _, tc := range testcases {
+		addrs := strings.Split(tc.input, ",")
+
+		gotIps := []string{}
+		gotPorts := []uint64{}
+		for j := 0; j < len(addrs); j++ {
+			gotIp, gotPort, err := ResolveIPAndPort(addrs[j])
+			assert.Nil(t, err)
+
+			gotIps = append(gotIps, gotIp)
+			gotPorts = append(gotPorts, gotPort)
+		}
+
+		assert.Equal(t, gotIps, tc.expectedIps,
+			fmt.Sprintf("Failed on %s. Expected %v, got %v.", tc.input, tc.expectedIps, gotIps),
+		)
+		assert.Equal(t, gotPorts, tc.expectedPorts,
+			fmt.Sprintf("Failed on %s. Expected %v, got %v.", tc.input, tc.expectedPorts, gotPorts),
+		)
+	}
+}

--- a/proxyd/nacos_test.go
+++ b/proxyd/nacos_test.go
@@ -46,6 +46,11 @@ func TestManyResolveIPAndPort(t *testing.T) {
 			[]string{"127.0.0.3", "127.0.0.2"},
 			[]uint64{7001, 7002},
 		},
+		{
+			"127.0.0.2:7001,127.0.0.2:7002",
+			[]string{"127.0.0.2", "127.0.0.2"},
+			[]uint64{7001, 7002},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Previous expected nacos config
```
[nacos]
namespace_id = "public"
urls = "online-nacosapi.okg.com:80,online-nacosapi.okg.com:80" # For service discovery, independent of instances
application_name = "app-name1" # This cannot specify many
external_listen_addr = "SINGLE_POD_IP:7001" # This is also singular
```
New nacos config
```
[nacos]
namespace_id = "public"
urls = "online-nacosapi.okg.com:80,online-nacosapi.okg.com:80"
application_name = "app-name-1,app-name-2"
external_ip = "POD_IP_ADDR" # Most likely retrieved from env
external_ports = "7001,7002"
```
The changes are to allow discovery of multiple applications running on the same pod.