### PR TITLE
[proxyd] fix group block consensus delay issue.

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -184,7 +184,7 @@ type BackendGroupConfig struct {
 
 	ConsensusBanPeriod          TOMLDuration `toml:"consensus_ban_period"`
 	ConsensusMaxUpdateThreshold TOMLDuration `toml:"consensus_max_update_threshold"`
-	ConsensusMaxBlockLag        uint64       `toml:"consensus_max_block_lag"`
+	ConsensusMaxBlockLag        int64        `toml:"consensus_max_block_lag"`
 	ConsensusMaxBlockRange      uint64       `toml:"consensus_max_block_range"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -40,6 +40,10 @@ type ConsensusPoller struct {
 	maxBlockLag        uint64
 	maxBlockRange      uint64
 	interval           time.Duration
+
+	// Add global lock and execution status flag
+	updateMux  sync.Mutex
+	isUpdating bool
 }
 
 type backendState struct {
@@ -186,7 +190,7 @@ func (ah *PollerAsyncHandler) Init() {
 	go func() {
 		for {
 			timer := time.NewTimer(ah.cp.interval)
-			log.Info("updating backend group consensus")
+			log.Debug("updating backend group consensus")
 			ah.cp.UpdateBackendGroupConsensus(ah.ctx)
 
 			select {
@@ -449,6 +453,23 @@ func (cp *ConsensusPoller) checkExpectedBlockTags(
 
 // UpdateBackendGroupConsensus resolves the current group consensus based on the state of the backends
 func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
+	// Check if an instance is already executing
+	cp.updateMux.Lock()
+	if cp.isUpdating {
+		log.Debug("UpdateBackendGroupConsensus already in progress, skipping")
+		cp.updateMux.Unlock()
+		return
+	}
+	cp.isUpdating = true
+	cp.updateMux.Unlock()
+
+	// Ensure execution status is reset when the method ends
+	defer func() {
+		cp.updateMux.Lock()
+		cp.isUpdating = false
+		cp.updateMux.Unlock()
+	}()
+
 	// get the latest block number from the tracker
 	currentConsensusBlockNumber := cp.GetLatestBlockNumber()
 
@@ -490,22 +511,57 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	if proposedBlock > 0 {
 		for !hasConsensus {
 			allAgreed := true
+
+			// Define result struct
+			type fetchResult struct {
+				be                *Backend
+				actualBlockNumber hexutil.Uint64
+				actualBlockHash   string
+				err               error
+			}
+
+			// Create channel and waitGroup
+			resultChan := make(chan fetchResult, len(candidates))
+			var wg sync.WaitGroup
+
+			// Concurrently call fetchBlock
 			for be := range candidates {
-				actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, be, proposedBlock.String())
-				if err != nil {
-					log.Warn("error updating backend", "name", be.Name, "err", err)
+				wg.Add(1)
+				go func(backend *Backend) {
+					defer wg.Done()
+					actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, backend, proposedBlock.String())
+
+					resultChan <- fetchResult{
+						be:                backend,
+						actualBlockNumber: actualBlockNumber,
+						actualBlockHash:   actualBlockHash,
+						err:               err,
+					}
+				}(be)
+			}
+
+			// Wait for all goroutines to complete
+			go func() {
+				wg.Wait()
+				close(resultChan)
+			}()
+
+			// Process results
+			for result := range resultChan {
+				if result.err != nil {
+					log.Warn("error updating backend", "name", result.be.Name, "err", result.err)
 					continue
 				}
 				if proposedBlockHash == "" {
-					proposedBlockHash = actualBlockHash
+					proposedBlockHash = result.actualBlockHash
 				}
-				blocksDontMatch := (actualBlockNumber != proposedBlock) || (actualBlockHash != proposedBlockHash)
+				blocksDontMatch := (result.actualBlockNumber != proposedBlock) || (result.actualBlockHash != proposedBlockHash)
 				if blocksDontMatch {
-					if currentConsensusBlockNumber >= actualBlockNumber {
+					if currentConsensusBlockNumber >= result.actualBlockNumber {
 						log.Warn("backend broke consensus",
-							"name", be.Name,
-							"actualBlockNumber", actualBlockNumber,
-							"actualBlockHash", actualBlockHash,
+							"name", result.be.Name,
+							"actualBlockNumber", result.actualBlockNumber,
+							"actualBlockHash", result.actualBlockHash,
 							"proposedBlock", proposedBlock,
 							"proposedBlockHash", proposedBlockHash)
 						broken = true
@@ -514,6 +570,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 					break
 				}
 			}
+
 			if allAgreed {
 				hasConsensus = true
 			} else {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -503,8 +503,10 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMaxUpdateThreshold > 0 {
 				copts = append(copts, WithMaxUpdateThreshold(time.Duration(bgcfg.ConsensusMaxUpdateThreshold)))
 			}
-			if bgcfg.ConsensusMaxBlockLag > 0 {
-				copts = append(copts, WithMaxBlockLag(bgcfg.ConsensusMaxBlockLag))
+			// Allow 0 here to disable lag checking
+			// If negative, don't set it and use the default (8)
+			if bgcfg.ConsensusMaxBlockLag >= 0 {
+				copts = append(copts, WithMaxBlockLag(uint64(bgcfg.ConsensusMaxBlockLag)))
 			}
 			if bgcfg.ConsensusMinPeerCount > 0 {
 				copts = append(copts, WithMinPeerCount(uint64(bgcfg.ConsensusMinPeerCount)))


### PR DESCRIPTION
updates:
1、允许consensus_max_block_lag=0生效，避免落后节点直接上线；
2、优化proxyd判定多节点的一致高度逻辑：并发调用节点rpc减少执行时间，加锁处理，避免同一时间多个任务执行造成结果冲突；
