### PR TITLE
ws: route requests from k8s ingress with custom path

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -237,8 +238,15 @@ func (s *Server) RPCListenAndServe(host string, port int) error {
 func (s *Server) WSListenAndServe(host string, port int) error {
 	s.srvMu.Lock()
 	hdlr := mux.NewRouter()
-	hdlr.HandleFunc("/", s.HandleWS)
 	hdlr.HandleFunc("/{authorization}", s.HandleWS)
+
+	routeCorrection := os.Getenv("WS_ROUTE_CORRECTION")
+	if routeCorrection != "" {
+		hdlr.HandleFunc(routeCorrection, s.HandleWS)
+	} else {
+		hdlr.HandleFunc("/", s.HandleWS)
+	}
+
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 	})

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -239,7 +239,7 @@ func (s *Server) WSListenAndServe(host string, port int) error {
 	hdlr := mux.NewRouter()
 	hdlr.HandleFunc("/", s.HandleWS)
 	hdlr.HandleFunc("/{authorization}", s.HandleWS)
-	hdlr.HandleFunc("/{path:.+/.+}", s.HandleWS) // 2 or more segments
+	hdlr.HandleFunc("/{path:.+/.+}", s.HandleManySegsWS) // 2 or more segments
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 	})

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -237,8 +237,10 @@ func (s *Server) RPCListenAndServe(host string, port int) error {
 func (s *Server) WSListenAndServe(host string, port int) error {
 	s.srvMu.Lock()
 	hdlr := mux.NewRouter()
+	// Original intent
+	hdlr.HandleFunc("/", s.HandleWS)
 	hdlr.HandleFunc("/{authorization}", s.HandleWS)
-	hdlr.HandleFunc("/{path:.*}", s.HandleWS)
+	hdlr.HandleFunc("/{path:.+/.+}", s.HandleWS) // 2 or more segments
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 	})

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"math/big"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -239,14 +238,7 @@ func (s *Server) WSListenAndServe(host string, port int) error {
 	s.srvMu.Lock()
 	hdlr := mux.NewRouter()
 	hdlr.HandleFunc("/{authorization}", s.HandleWS)
-
-	routeCorrection := os.Getenv("WS_ROUTE_CORRECTION")
-	if routeCorrection != "" {
-		hdlr.HandleFunc(routeCorrection, s.HandleWS)
-	} else {
-		hdlr.HandleFunc("/", s.HandleWS)
-	}
-
+	hdlr.HandleFunc("/{path:.*}", s.HandleWS)
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 	})

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -237,7 +237,6 @@ func (s *Server) RPCListenAndServe(host string, port int) error {
 func (s *Server) WSListenAndServe(host string, port int) error {
 	s.srvMu.Lock()
 	hdlr := mux.NewRouter()
-	// Original intent
 	hdlr.HandleFunc("/", s.HandleWS)
 	hdlr.HandleFunc("/{authorization}", s.HandleWS)
 	hdlr.HandleFunc("/{path:.+/.+}", s.HandleWS) // 2 or more segments

--- a/proxyd/xlayer_server.go
+++ b/proxyd/xlayer_server.go
@@ -1,0 +1,20 @@
+package proxyd
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func (s *Server) HandleManySegsWS(w http.ResponseWriter, r *http.Request) {
+	// >2 segments (/{...}/{...}) we check.
+	if matched, _ := regexp.MatchString("^/[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)+$", r.URL.Path); !matched {
+		log.Warn("invalid WS path rejected", "path", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// Call the original HandleWS if validation passes
+	s.HandleWS(w, r)
+}


### PR DESCRIPTION
WS connections are served via k8s ingress, and sometimes custom paths for specified for each request. The previous proxyd only accepts `/` or `/{authorization}` in request URIs, resulting in a 404 being returned whenever a URI with 2 or more segments is forwarded.

Previous code handles `/` and a single segment for `[authentication]`, but if `/unlimited/abc` (2 segments) is used, there is no handler for that.
```go
hdlr.HandleFunc("/", s.HandleWS)
hdlr.HandleFunc("/{authorization}", s.HandleWS) // <-- only this has special function
```

So using `/{path:.+/.+}` will allow us to match 2 or more segments whenever OPs team assigns arbitrary paths.