### PR TITLE
feat(proxyd): add consensus rewrite support for eth_getBlockReceipts 

### DIFF
--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -71,6 +71,7 @@ The following request methods are rewritten:
 * `eth_getBlockByNumber`
 * `eth_getTransactionByBlockNumberAndIndex`
 * `eth_getUncleByBlockNumberAndIndex`
+* `eth_getBlockReceipts`
 * `debug_getRawReceipts`
 
 And `eth_blockNumber` response is overridden with current block consensus.

--- a/proxyd/otel_test.go
+++ b/proxyd/otel_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMetricsClient(t *testing.T) {
-	client, err := NewMetricsClient(context.Background(), "fullnode-test-service", "")
+	client, err := NewMetricsClient(context.Background(), "fullnode-test-service", "", "proxyd", []attribute.KeyValue{}, 5*time.Second)
 	assert.NoError(t, err)
 	defer client.Close(context.Background())
 	t.Run("Counter", func(t *testing.T) {

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -65,7 +65,7 @@ func RewriteRequest(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResul
 	case "eth_getLogs",
 		"eth_newFilter":
 		return rewriteRange(rctx, req, res, 0)
-	case "debug_getRawReceipts", "consensus_getReceipts":
+	case "debug_getRawReceipts", "consensus_getReceipts", "eth_getBlockReceipts":
 		return rewriteParam(rctx, req, res, 0, true, false)
 	case "eth_getBalance",
 		"eth_getCode",

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -621,6 +621,7 @@ func TestRewriteRequest(t *testing.T) {
 	tests = generalize(tests, "eth_getBlockByNumber", "eth_getTransactionByBlockNumberAndIndex")
 	tests = generalize(tests, "eth_getBlockByNumber", "eth_getUncleByBlockNumberAndIndex")
 	tests = generalize(tests, "eth_getStorageSlotAt", "eth_getProof")
+	tests = generalize(tests, "debug_getRawReceipts", "eth_getBlockReceipts")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds consensus rewrite support for the `eth_getBlockReceipts` method in proxyd, enabling it to participate in the consensus-aware request rewriting system.

## Changes

- **Added `eth_getBlockReceipts` to rewrite method list**: The method is now included in the consensus rewrite logic alongside `debug_getRawReceipts` and `consensus_getReceipts`
- **Updated documentation**: Added `eth_getBlockReceipts` to the list of rewritten request methods in README.md
- **Fixed test configuration**: Corrected the `NewMetricsClient` function call in `otel_test.go` by adding missing parameters
- **Added test coverage**: Extended test cases to include `eth_getBlockReceipts` method testing

## Technical Details

The `eth_getBlockReceipts` method is now handled by the `rewriteParam` function with the following configuration:
- Position: 0 (first parameter)
- Required: true
- Block number or hash: false

This ensures that when clients request block receipts using consensus tags (`latest`, `safe`, `finalized`), proxyd will rewrite the request to use the resolved consensus block number before forwarding to backends.

## Testing

- All existing tests continue to pass
- New test cases added for `eth_getBlockReceipts` method
- Test coverage includes various scenarios: latest tag, within range, out of range, and missing parameters

## Impact

This change improves the consistency of block receipt responses when using consensus-aware backend groups, ensuring clients receive receipts from the same consensus block across different backend services.